### PR TITLE
A variety of improvements

### DIFF
--- a/assemble_distro.py
+++ b/assemble_distro.py
@@ -69,6 +69,8 @@ def main():
     pkgs = sys.argv[1:]
     if len(pkgs) == 0:
         pkgs = sorted([d for d in os.listdir(".")  if os.path.isdir(d) and not skip(d)])
+    else:
+        pkgs = [x.removesuffix("/meta.json") for x in pkgs]
 
     # Make packages.tar.gz
     make_packages_tar_gz(archive_dir, release_dir, pkgs)

--- a/assemble_distro.py
+++ b/assemble_distro.py
@@ -16,7 +16,7 @@ import sys
 import os
 import gzip
 from tempfile import TemporaryDirectory
-from download_packages import download_archive, metadata_fname
+from download_packages import download_archive, metadata_fname, normalize_pkg_name
 
 from scan_for_updates import all_packages
 from utils import sha256file
@@ -70,7 +70,7 @@ def main():
     if len(pkgs) == 0:
         pkgs = all_packages()
     else:
-        pkgs = [x.removesuffix("/meta.json") for x in pkgs]
+        pkgs = [normalize_pkg_name(x) for x in pkgs]
 
     # Make packages.tar.gz
     make_packages_tar_gz(archive_dir, release_dir, pkgs)

--- a/assemble_distro.py
+++ b/assemble_distro.py
@@ -16,7 +16,7 @@ import sys
 import os
 import gzip
 from tempfile import TemporaryDirectory
-from download_packages import download_archive
+from download_packages import download_archive, metadata_fname
 
 from scan_for_updates import all_packages
 from utils import sha256file
@@ -25,7 +25,7 @@ from utils import sha256file
 def make_package_info_json(pkgs):
     package_info = dict()
     for p in pkgs:
-        with open(p + "/meta.json") as f:
+        with open(metadata_fname(p)) as f:
             package_info[p] = json.load(f)
     return package_info
 

--- a/assemble_distro.py
+++ b/assemble_distro.py
@@ -18,7 +18,7 @@ import gzip
 from tempfile import TemporaryDirectory
 from download_packages import download_archive
 
-from scan_for_updates import skip
+from scan_for_updates import all_packages
 from utils import sha256file
 
 
@@ -68,7 +68,7 @@ def main():
 
     pkgs = sys.argv[1:]
     if len(pkgs) == 0:
-        pkgs = sorted([d for d in os.listdir(".")  if os.path.isdir(d) and not skip(d)])
+        pkgs = all_packages()
     else:
         pkgs = [x.removesuffix("/meta.json") for x in pkgs]
 

--- a/cleanup_archives.py
+++ b/cleanup_archives.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+
+#############################################################################
+##
+##  This file is part of GAP, a system for computational discrete algebra.
+##
+##  Copyright of GAP belongs to its developers, whose names are too numerous
+##  to list here. Please refer to the COPYRIGHT file for details.
+##
+##  SPDX-License-Identifier: GPL-2.0-or-later
+##
+import os
+from utils import all_packages, archive_name
+
+# remove unused files from _archives
+def cleanup_archives():
+    archive_dir = "_archives"
+    pkgs = all_packages()
+    needed_archives = set([archive_name(p) for p in pkgs])
+    all_archives = set(os.listdir(archive_dir))
+    for fname in all_archives - needed_archives:
+        path = os.path.join(archive_dir, fname)
+        print("removing", path)
+        os.remove(path)
+
+if __name__ == "__main__":
+    cleanup_archives()

--- a/download_dependencies.py
+++ b/download_dependencies.py
@@ -31,11 +31,10 @@ from validate_package import unpack_archive
 def download_dependencies(pkg_name: str) -> None:
     pkg_json = metadata(pkg_name)
     seen = set()
-    pkgs_in_distro = set(os.listdir(os.getcwd()))
 
     for pkg, _ in pkg_json["Dependencies"]["NeededOtherPackages"]:
         pkg = pkg.lower()
-        if not pkg in pkgs_in_distro:
+        if not os.path.isfile(metadata_fname(pkg)):
             error(
                 "{}: dependency {} not in distro, giving up!".format(
                     pkg_name, pkg

--- a/download_dependencies.py
+++ b/download_dependencies.py
@@ -52,7 +52,7 @@ def download_dependencies(pkg_name: str) -> None:
 
 def main(pkgs) -> None:
     for pkg in pkgs:
-        download_dependencies(pkg)
+        download_dependencies(pkg.removesuffix("/meta.json"))
 
 
 if __name__ == "__main__":

--- a/download_dependencies.py
+++ b/download_dependencies.py
@@ -21,7 +21,7 @@ import sys
 
 from accepts import accepts
 
-from download_packages import download_archive, metadata
+from download_packages import download_archive, metadata, normalize_pkg_name
 from utils import error
 from validate_package import unpack_archive
 
@@ -52,7 +52,7 @@ def download_dependencies(pkg_name: str) -> None:
 
 def main(pkgs) -> None:
     for pkg in pkgs:
-        download_dependencies(pkg.removesuffix("/meta.json"))
+        download_dependencies(normalize_pkg_name(pkg))
 
 
 if __name__ == "__main__":

--- a/download_dependencies.py
+++ b/download_dependencies.py
@@ -21,10 +21,10 @@ import sys
 
 from accepts import accepts
 
-from download_packages import download_archive, metadata, normalize_pkg_name
-from utils import error
+from download_packages import download_archive
 from validate_package import unpack_archive
 
+from utils import error, normalize_pkg_name, metadata, metadata_fname
 
 # TODO allow downloading of SuggestedPackages too
 @accepts(str)

--- a/download_packages.py
+++ b/download_packages.py
@@ -14,19 +14,22 @@
 
 """
 This module can be used as a script to download package archives into the
-`_archives` directory of the cwd. The packages to download should be given as
-command line arguments, each given name must correspond to a subdirectory in
-the cwd named `pkg_name` and containing a `meta.json` file (i.e. should be run
-inside the `PackageDistro` git repo from:
+`_archives` directory of the cwd. The command should be run inside the
+`PackageDistro` git repo from:
 
 https://github.com/gap-system/PackageDistro
+
+The packages to download should be given as command line arguments, each
+given name must either correspond to a subdirectory in the cwd named
+`pkg_name` and containing a `meta.json` file, or be of the form
+`pkg_name/meta.json`.
 
 If the archive already exists in the `_archives` directory, then it is not
 downloaded again.
 
 Usage:
 
-    > _tools/download_packages.py digraphs walrus
+    > _tools/download_packages.py digraphs walrus/meta.json
     digraphs: _archives/digraphs-1.5.0.tar.gz already exists, not downloading again
     walrus: _archives/walrus-0.9991.tar.gz already exists, not downloading again
 
@@ -118,7 +121,7 @@ def download_archive(  # pylint: disable=inconsistent-return-statements
 def main(pkg_names) -> None:
     archive_dir = "_archives"
     for pkg_name in pkg_names:
-        download_archive(archive_dir, pkg_name)
+        download_archive(archive_dir, pkg_name.removesuffix("/meta.json"))
 
 
 if __name__ == "__main__":

--- a/download_packages.py
+++ b/download_packages.py
@@ -46,10 +46,13 @@ from accepts import accepts
 
 from utils import error, notice
 
+@accepts(str)
+def metadata_fname(pkg_name: str) -> str:
+    return join(pkg_name, "meta.json")
 
 @accepts(str)
 def metadata(pkg_name: str) -> dict:
-    fname = join(pkg_name, "meta.json")
+    fname = metadata_fname(pkg_name)
     pkg_json = {}
 
     try:

--- a/download_packages.py
+++ b/download_packages.py
@@ -47,6 +47,10 @@ from accepts import accepts
 from utils import error, notice
 
 @accepts(str)
+def normalize_pkg_name(pkg_name: str) -> str:
+    return pkg_name.removesuffix("/meta.json")
+
+@accepts(str)
 def metadata_fname(pkg_name: str) -> str:
     return join(pkg_name, "meta.json")
 
@@ -124,7 +128,7 @@ def download_archive(  # pylint: disable=inconsistent-return-statements
 def main(pkg_names) -> None:
     archive_dir = "_archives"
     for pkg_name in pkg_names:
-        download_archive(archive_dir, pkg_name.removesuffix("/meta.json"))
+        download_archive(archive_dir, normalize_pkg_name(pkg_name))
 
 
 if __name__ == "__main__":

--- a/download_packages.py
+++ b/download_packages.py
@@ -36,7 +36,6 @@ Usage:
 """
 
 
-import json
 import os
 import sys
 from os.path import join
@@ -44,44 +43,7 @@ from os.path import join
 import requests
 from accepts import accepts
 
-from utils import error, notice
-
-@accepts(str)
-def normalize_pkg_name(pkg_name: str) -> str:
-    return pkg_name.removesuffix("/meta.json")
-
-@accepts(str)
-def metadata_fname(pkg_name: str) -> str:
-    return join(pkg_name, "meta.json")
-
-@accepts(str)
-def metadata(pkg_name: str) -> dict:
-    fname = metadata_fname(pkg_name)
-    pkg_json = {}
-
-    try:
-        with open(fname, "r", encoding="utf-8") as f:
-            pkg_json = json.load(f)
-    except (OSError, IOError):
-        error("{}: file {} not found".format(pkg_name, fname))
-    except json.JSONDecodeError as e:
-        error("{}: invalid json in {}\n{}".format(pkg_name, fname, e.msg))
-    return pkg_json
-
-
-@accepts(str)
-def archive_name(pkg_name: str) -> str:
-    pkg_json = metadata(pkg_name)
-    return (
-        pkg_json["ArchiveURL"].split("/")[-1]
-        + pkg_json["ArchiveFormats"].split(" ")[0]
-    )
-
-
-@accepts(str)
-def archive_url(pkg_name: str) -> str:
-    pkg_json = metadata(pkg_name)
-    return pkg_json["ArchiveURL"] + pkg_json["ArchiveFormats"].split(" ")[0]
+from utils import error, notice, normalize_pkg_name, archive_name, archive_url
 
 
 @accepts(str, str, int)

--- a/scan_for_updates.py
+++ b/scan_for_updates.py
@@ -32,31 +32,9 @@ from os.path import join
 import requests
 from accepts import accepts
 
-from utils import error, notice, warning
-from download_packages import download_archive, metadata, metadata_fname
+from download_packages import download_archive
 
-
-@accepts(str)
-def skip(string: str) -> bool:
-    return (
-        string.startswith(".")
-        or string.startswith("_")
-        or string == "README.md"
-    )
-
-
-def all_packages():
-    pkgs = sorted(os.listdir(os.getcwd()))
-    return [d for d in pkgs if os.path.isdir(d) and os.path.isfile(metadata_fname(d)) and not skip(d)]
-
-
-@accepts(str)
-def sha256(fname: str) -> str:
-    hash_archive = hashlib.sha256()
-    with open(fname, "rb") as f:
-        for chunk in iter(lambda: f.read(1024), b""):
-            hash_archive.update(chunk)
-    return hash_archive.hexdigest()
+from utils import notice, error, warning, all_packages, metadata, metadata_fname, skip, sha256
 
 
 @accepts(str)

--- a/scan_for_updates.py
+++ b/scan_for_updates.py
@@ -33,7 +33,7 @@ import requests
 from accepts import accepts
 
 from utils import error, notice, warning
-from download_packages import download_archive, metadata
+from download_packages import download_archive, metadata, metadata_fname
 
 
 @accepts(str)
@@ -47,7 +47,7 @@ def skip(string: str) -> bool:
 
 def all_packages():
     pkgs = sorted(os.listdir(os.getcwd()))
-    return [d for d in pkgs if os.path.isdir(d) and os.path.isfile(join(d, 'meta.json')) and not skip(d)]
+    return [d for d in pkgs if os.path.isdir(d) and os.path.isfile(metadata_fname(d)) and not skip(d)]
 
 
 @accepts(str)
@@ -154,7 +154,7 @@ def add_sha256_to_json(pkginfos_dir: str, archive_name_lookup: dict) -> None:
         if skip(pkgname):
             continue
         pkgname = pkgname.split(".")[0]
-        pkg_json_file = "{}/meta.json".format(pkgname)
+        pkg_json_file = metadata_fname(pkgname)
 
         try:
             pkg_archive = archive_name_lookup[pkgname]
@@ -168,7 +168,7 @@ def add_sha256_to_json(pkginfos_dir: str, archive_name_lookup: dict) -> None:
             join(pkginfos_dir, pkgname + ".g")
         )
         pkg_json["ArchiveSHA256"] = sha256(pkg_archive)
-        notice("{0}: writing updated {0}/meta.json".format(pkgname))
+        notice("{0}: writing updated {0}".format(pkg_json_file))
         with open(pkg_json_file, "w", encoding="utf-8") as f:
             json.dump(pkg_json, f, indent=2, ensure_ascii=False, sort_keys=True)
             f.write("\n")

--- a/scan_for_updates.py
+++ b/scan_for_updates.py
@@ -45,6 +45,11 @@ def skip(string: str) -> bool:
     )
 
 
+def all_packages():
+    pkgs = sorted(os.listdir(os.getcwd()))
+    return [d for d in pkgs if os.path.isdir(d) and os.path.isfile(join(d, 'meta.json')) and not skip(d)]
+
+
 @accepts(str)
 def sha256(fname: str) -> str:
     hash_archive = hashlib.sha256()
@@ -111,9 +116,8 @@ def scan_for_updates(pkginfos_dir: str) -> None:
     if not os.path.exists(pkginfos_dir):
         os.mkdir(pkginfos_dir)
     assert os.path.isdir(pkginfos_dir)
-    for pkgname in sorted(os.listdir(os.getcwd())):
-        if not skip(pkgname) and os.path.isdir(pkgname):
-            scan_for_one_update(pkginfos_dir, pkgname)
+    for pkgname in all_packages():
+        scan_for_one_update(pkginfos_dir, pkgname)
 
 
 @accepts(str)

--- a/tests/test_download_packages.py
+++ b/tests/test_download_packages.py
@@ -22,10 +22,14 @@ sys.path.insert(
 
 
 from download_packages import (
-    archive_name,
-    archive_url,
     download_archive,
     main,
+)
+
+# TODO: move the tests for these functions to their own test file?
+from utils import (
+    archive_name,
+    archive_url,
     metadata,
 )
 

--- a/utils.py
+++ b/utils.py
@@ -7,19 +7,14 @@
 ##
 ##  SPDX-License-Identifier: GPL-2.0-or-later
 ##
-import contextlib
 import hashlib
+import json
 import os
-import re
-import shutil
-import subprocess
 import sys
 
-CURRENT_REPO_NAME = os.environ.get("GITHUB_REPOSITORY", "gap-system/gap")
+from accepts import accepts
+from os.path import join
 
-# Initialized by initialize_github
-GITHUB_INSTANCE = None
-CURRENT_REPO = None
 
 # print notices in green
 def notice(msg):
@@ -37,244 +32,59 @@ def error(msg):
     sys.exit(1)
 
 
-def verify_command_available(cmd):
-    if shutil.which(cmd) == None:
-        error(f"the '{cmd}' command was not found, please install it")
-    # TODO: do the analog of this in ReleaseTools bash script:
-    # command -v curl >/dev/null 2>&1 ||
-    #     error "the 'curl' command was not found, please install it"
-
-
-def verify_git_repo():
-    res = subprocess.run(
-        ["git", "--git-dir=.git", "rev-parse"], stderr=subprocess.DEVNULL
+@accepts(str)
+def skip(string: str) -> bool:
+    return (
+        string.startswith(".")
+        or string.startswith("_")
+        or string == "README.md"
     )
-    if res.returncode != 0:
-        error("current directory is not a git root directory")
 
+def all_packages():
+    pkgs = sorted(os.listdir(os.getcwd()))
+    return [d for d in pkgs if os.path.isdir(d) and os.path.isfile(metadata_fname(d)) and not skip(d)]
 
-# check for uncommitted changes
-def is_git_clean():
-    res = subprocess.run(["git", "update-index", "--refresh"])
-    if res.returncode == 0:
-        res = subprocess.run(["git", "diff-index", "--quiet", "HEAD", "--"])
-    return res.returncode == 0
+@accepts(str)
+def sha256(fname: str) -> str:
+    hash_archive = hashlib.sha256()
+    with open(fname, "rb") as f:
+        for chunk in iter(lambda: f.read(1024), b""):
+            hash_archive.update(chunk)
+    return hash_archive.hexdigest()
 
+@accepts(str)
+def normalize_pkg_name(pkg_name: str) -> str:
+    return pkg_name.removesuffix("/meta.json")
 
-def verify_git_clean():
-    if not is_git_clean():
-        error("uncommitted changes detected")
+@accepts(str)
+def metadata_fname(pkg_name: str) -> str:
+    return join(pkg_name, "meta.json")
 
+@accepts(str)
+def metadata(pkg_name: str) -> dict:
+    fname = metadata_fname(pkg_name)
+    pkg_json = {}
 
-# from https://code.activestate.com/recipes/576620-changedirectory-context-manager/
-@contextlib.contextmanager
-def working_directory(path):
-    """A context manager which changes the working directory to the given
-    path, and then changes it back to its previous value on exit.
-
-    """
-    prev_cwd = os.getcwd()
-    os.chdir(path)
-    yield
-    os.chdir(prev_cwd)
-
-
-# helper for extracting values of variables set in the GAP Makefiles.rules
-def get_makefile_var(var):
-    res = subprocess.run(
-        ["make", f"print-{var}"], check=True, capture_output=True
-    )
-    kv = res.stdout.decode("ascii").strip().split("=")
-    assert len(kv) == 2
-    assert kv[0] == var
-    return kv[1]
-
-
-# compute the sha256 checksum of a file
-def sha256file(path):
-    h = hashlib.sha256()
-    with open(path, "rb") as f:
-        # Read and update hash string value in blocks of 4K
-        for data in iter(lambda: f.read(4096), b""):
-            h.update(data)
-        return h.hexdigest()
-
-
-# read a file into memory, apply some transformations, and write it back
-def patchfile(path, pattern, repl):
-    # Read in the file
-    with open(path, "r") as file:
-        filedata = file.read()
-
-    # Replace the target string
-    filedata = re.sub(pattern, repl, filedata)
-
-    # Write the file out again
-    with open(path, "w") as file:
-        file.write(filedata)
-
-
-# download file at the given URL to path `dst`
-def download(url, dst):
-    res = subprocess.run(["curl", "-L", "-C", "-", "-o", dst, url])
-    if res.returncode != 0:
-        error("failed downloading " + url)
-
-
-def file_matches_checksumfile(filename):
-    with open(filename + ".sha256", "r") as f:
-        expected_checksum = f.read().strip()
-    return expected_checksum == sha256file(filename)
-
-
-def verify_via_checksumfile(filename):
-    if not file_matches_checksumfile(filename):
-        error(
-            f"checksum for '{filename}' expected to be {expected_checksum} but got {actual_checksum}"
-        )
-
-
-# Download file at the given URL to path `dst`, unless we detect that a file
-# already exists at `dst` with the expected checksum.
-def download_with_sha256(url, dst):
-    download(url + ".sha256", dst + ".sha256")
-    if os.path.isfile(dst):
-        if file_matches_checksumfile(dst):
-            return
-        notice(
-            f"{dst} exists but does not match the checksumfile; redownloading"
-        )
-    download(url, dst)
-    verify_via_checksumfile(dst)
-
-
-# Run what ever <args> command and create appropriate log file
-def run_with_log(args, name, msg=None):
-    if msg == None:
-        msg = name
-    with open("../" + name + ".log", "w") as fp:
-        try:
-            subprocess.run(args, check=True, stdout=fp, stderr=fp)
-        except subprocess.CalledProcessError:
-            error(msg + " failed. See " + name + ".log.")
-
-
-def is_possible_gap_release_tag(tag):
-    return re.fullmatch(r"v[1-9]+\.[0-9]+\.[0-9]+", tag) != None
-
-
-def verify_is_possible_gap_release_tag(tag):
-    if not is_possible_gap_release_tag(tag):
-        error(f"{tag} does not look like the tag of a GAP release version")
-
-
-# Error checked git fetch of tags
-def safe_git_fetch_tags():
     try:
-        subprocess.run(["git", "fetch", "--tags"], check=True)
-    except subprocess.CalledProcessError:
-        error(
-            "failed to fetch tags, you may have to do \n"
-            + "git fetch --tags -f"
-        )
+        with open(fname, "r", encoding="utf-8") as f:
+            pkg_json = json.load(f)
+    except (OSError, IOError):
+        error("{}: file {} not found".format(pkg_name, fname))
+    except json.JSONDecodeError as e:
+        error("{}: invalid json in {}\n{}".format(pkg_name, fname, e.msg))
+    return pkg_json
 
 
-# lightweight vs annotated
-# https://stackoverflow.com/questions/40479712/how-can-i-tell-if-a-given-git-tag-is-annotated-or-lightweight#40499437
-def is_annotated_git_tag(tag):
-    res = subprocess.run(
-        ["git", "for-each-ref", "refs/tags/" + tag],
-        capture_output=True,
-        text=True,
+@accepts(str)
+def archive_name(pkg_name: str) -> str:
+    pkg_json = metadata(pkg_name)
+    return (
+        pkg_json["ArchiveURL"].split("/")[-1]
+        + pkg_json["ArchiveFormats"].split(" ")[0]
     )
-    return res.returncode == 0 and res.stdout.split()[1] == "tag"
 
 
-def check_git_tag_for_release(tag):
-    if not is_annotated_git_tag(tag):
-        error(f"There is no annotated tag {tag}")
-    # check that tag points to HEAD
-    tag_commit = subprocess.run(
-        ["git", "rev-parse", tag + "^{}"],
-        check=True,
-        capture_output=True,
-        text=True,
-    ).stdout.strip()
-    head = subprocess.run(
-        ["git", "rev-parse", "HEAD"], check=True, capture_output=True, text=True
-    ).stdout.strip()
-    if tag_commit != head:
-        error(
-            f"The tag {tag} does not point to the current commit {head} but"
-            + f" instead points to {tag_commit}"
-        )
-
-
-# sets the global variables GITHUB_INSTANCE and CURRENT_REPO
-# If no token is provided, this uses the value of the environment variable
-# GITHUB_TOKEN.
-def initialize_github(token=None):
-    global GITHUB_INSTANCE, CURRENT_REPO
-    if GITHUB_INSTANCE != None or CURRENT_REPO != None:
-        error(
-            "Global variables GITHUB_INSTANCE and CURRENT_REPO"
-            + " are already initialized."
-        )
-    if token == None and "GITHUB_TOKEN" in os.environ:
-        token = os.environ["GITHUB_TOKEN"]
-    if token == None:
-        temp = subprocess.run(
-            ["git", "config", "--get", "github.token"],
-            text=True,
-            capture_output=True,
-        )
-        if temp.returncode == 0:
-            token = temp.stdout.strip()
-    if token == None and os.path.isfile(
-        os.path.expanduser("~") + "/.github_shell_token"
-    ):
-        with open(
-            os.path.expanduser("~") + "/.github_shell_token", "r"
-        ) as token_file:
-            token = token_file.read().strip()
-    if token == None:
-        error("Error: no access token found or provided")
-    g = github.Github(token)
-    GITHUB_INSTANCE = g
-    notice(f"Accessing repository {CURRENT_REPO_NAME}")
-    try:
-        CURRENT_REPO = GITHUB_INSTANCE.get_repo(CURRENT_REPO_NAME)
-    except github.GithubException:
-        error("Error: the access token may be incorrect")
-
-
-# Given the <filename> of a file that does not end with .sha256, create or get
-# the corresponding sha256 checksum file <filename>.sha256, (comparing checksums
-# just to be safe, in the latter case). Then upload the files <filename> and
-# <filename>.sha256 as assets to the GitHub <release>.
-# Files already ending in ".sha256" are ignored.
-def upload_asset_with_checksum(release, filename):
-    if not os.path.isfile(filename):
-        error(f"{filename} not found")
-
-    if filename.endswith(".sha256"):
-        notice(f"Skipping provided checksum file {filename}")
-        return
-
-    notice(f"Processing {filename}")
-
-    checksum_filename = filename + ".sha256"
-    if os.path.isfile(checksum_filename):
-        notice("Comparing actual checksum with pre-existing checksum file")
-        verify_via_checksumfile(filename)
-    else:
-        notice("Writing new checksum file")
-        with open(checksum_filename, "w") as checksumfile:
-            checksumfile.write(sha256file(filename))
-
-    for file in [filename, checksum_filename]:
-        try:
-            notice(f"Uploading {file}")
-            release.upload_asset(file)
-        except github.GithubException:
-            error("Error: The upload failed")
+@accepts(str)
+def archive_url(pkg_name: str) -> str:
+    pkg_json = metadata(pkg_name)
+    return pkg_json["ArchiveURL"] + pkg_json["ArchiveFormats"].split(" ")[0]

--- a/validate_package.py
+++ b/validate_package.py
@@ -39,9 +39,11 @@ from os.path import join
 
 from accepts import accepts
 
-from download_packages import archive_name, metadata, download_archive, normalize_pkg_name
-from scan_for_updates import download_pkg_info, gap_exec, sha256
-from utils import notice, warning
+from download_packages import download_archive
+from scan_for_updates import download_pkg_info, gap_exec
+
+from utils import notice, warning, normalize_pkg_name, archive_name, metadata, sha256
+
 
 
 def unpack_archive(archive_dir, unpack_dir, pkg_name):

--- a/validate_package.py
+++ b/validate_package.py
@@ -16,9 +16,10 @@
 Runs some basic validation of the pkgname/meta.json against the package
 archive, and the old meta data.
 
-Should be run after scan_for_updates.py, as follows
+Should be run after scan_for_updates.py. Arguments can be either package
+names, or the path to a meta.json file. For example:
 
-    _tools/validate_package.py  aclib digraphs walrus
+    _tools/validate_package.py  aclib digraphs walrus/meta.json
     aclib: _archives/aclib-1.3.2.tar.gz already exists, not downloading again
     aclib: unpacking _archives/aclib-1.3.2.tar.gz into _unpacked_archives ...
     aclib: current release version is 1.3.2, but previous release version was 1.3.2, FAILED!
@@ -140,4 +141,4 @@ def main(pkg_name):
 
 if __name__ == "__main__":
     for i in range(1, len(sys.argv)):
-        main(sys.argv[i])
+        main(sys.argv[i].removesuffix("/meta.json"))

--- a/validate_package.py
+++ b/validate_package.py
@@ -40,7 +40,7 @@ from os.path import join
 
 from accepts import accepts
 
-from download_packages import archive_name, metadata, download_archive
+from download_packages import archive_name, metadata, download_archive, normalize_pkg_name
 from scan_for_updates import download_pkg_info, gap_exec, sha256
 from utils import notice, warning
 
@@ -141,4 +141,4 @@ def main(pkg_name):
 
 if __name__ == "__main__":
     for i in range(1, len(sys.argv)):
-        main(sys.argv[i].removesuffix("/meta.json"))
+        main(normalize_pkg_name(sys.argv[i]))

--- a/validate_package.py
+++ b/validate_package.py
@@ -34,8 +34,7 @@ names, or the path to a meta.json file. For example:
 
 import os
 import sys
-import tarfile
-import zipfile
+import shutil
 from os.path import join
 
 from accepts import accepts
@@ -49,26 +48,8 @@ def unpack_archive(archive_dir, unpack_dir, pkg_name):
     archive_fname = join(archive_dir, archive_name(pkg_name))
     if not os.path.exists(unpack_dir):
         os.mkdir(unpack_dir)
-    ext = archive_fname.split(".")[-1]
-    notice(
-        "{}: unpacking {} into {} ...".format(
-            pkg_name, archive_fname, unpack_dir
-        )
-    )
-
-    if ext.endswith("gz") or ext.endswith("bz2"):
-        with tarfile.open(archive_fname) as archive:
-            archive.extractall(unpack_dir)
-    elif ext.endswith("zip"):
-        with zipfile.ZipFile(archive_fname) as archive:
-            archive.extractall(unpack_dir)
-    else:
-        notice(
-            "{}: bad archive extension {}, skipping {}".format(
-                pkg_name, ext, archive_fname
-            )
-        )
-
+    notice("unpacking {} into {} ...".format(archive_fname, unpack_dir))
+    shutil.unpack_archive(archive_fname, unpack_dir)
 
 def unpacked_archive_name(unpack_dir, pkg_name):
     for x in os.listdir(unpack_dir):


### PR DESCRIPTION
- Allow passing either package names or meta.json path as CLI arguments: This is often convenient when using the tools interactively. The `normalize_pkg_name` helper is used for that: it maps package names and paths to meta.json files both to package names
- Add all_packages() helper to have a uniform way to get, well, all packages. The check now also looks for `meta.json` file, so the check also got tighter
- Add metadata_fname helper to map package names to `meta.json` files.

The common goal behind the final two changes is to make it easy to eventually move the packages into a subdirectory.
